### PR TITLE
Handle case where gdk_pixbuf can't load an SVG graphic

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -32,11 +32,15 @@ pub const ZOOM_IN_ICON_SVG: &str = include_str!("./resources/zoom-in-icon.svg");
 pub const ZOOM_OUT_ICON_SVG: &str = include_str!("./resources/zoom-out-icon.svg");
 
 pub fn svg_to_image_widget(svg: &'static str) -> gtk::Image {
-    let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_read(svg.as_bytes()).unwrap();
-    let pixbuf = pixbuf
-        .scale_simple(24, 24, gtk::gdk_pixbuf::InterpType::Tiles)
-        .unwrap();
-    let image = gtk::Image::from_pixbuf(Some(&pixbuf));
-    image.set_visible(true);
-    image
+    if let Ok(pixbuf) = gtk::gdk_pixbuf::Pixbuf::from_read(svg.as_bytes()) {
+        let pixbuf = pixbuf
+            .scale_simple(24, 24, gtk::gdk_pixbuf::InterpType::Tiles)
+            .unwrap();
+        let image = gtk::Image::from_pixbuf(Some(&pixbuf));
+        image.set_visible(true);
+        image
+    } else {
+        println!("Failed to load SVG as pixbuf.");
+        return gtk::Image::default()
+    }
 }


### PR DESCRIPTION
Hey :)

For some reason my system often has problems with GTK applications. I'm running Sway on NixOS.

One ususal problem I face is that icons are not loaded. This is the case with gerb as well, but this time I had to make this small change in order to be able to open a glyph.

```
$ cargo run
...
(gerb:2399975): Gtk-WARNING **: 03:45:15.166: Could not find the icon 'object-select-symbolic-ltr'. The 'hicolor' theme
was not found either, perhaps you need to install it.
You can get a copy from:
        http://icon-theme.freedesktop.org/releases

(gerb:2399975): Gtk-WARNING **: 03:45:15.652: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/bullet-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.
open-glyph-edit received!
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { domain: gdk-pixbuf-error-quark, code: 3, message: "Unrecognized image file format" }', src/resources.rs:35:69
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I have no clue what's the culprit here, but figured not crashing with broken icons is preferable to crashing.

Cheers,
Kerstin